### PR TITLE
updated link to Docker Manual with screenshots

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -11,7 +11,12 @@ In order to start developing you need to satisfy the following prerequisites:
 It is recommended you allocate at least 4GB of RAM to docker:
 
 - [Instructions for Windows](https://docs.docker.com/docker-for-windows/#resources)
-- [Instructions for macOS](https://docs.docker.com/docker-for-mac/#resources)
+- [Instructions for macOS](https://docs.docker.com/desktop/settings/mac/#advanced)
+
+Here is a screenshot showing the relevant setting in the Help Manual
+![image](https://user-images.githubusercontent.com/11910293/206360646-8d7c0d31-7b0f-4a15-afc8-c586e9eaeba2.png)
+Here is a screenshot showing the settings in Docker Desktop on Mac
+![image](https://user-images.githubusercontent.com/11910293/206360688-dc0fe0d7-5bdb-47c6-a159-49f2d31d5ac9.png)
 
 ## Bootstrap Containers for development
 


### PR DESCRIPTION
1. Update the link as the old link was pointing to a wrong place
2. Took 2 screenshots - one from the manual page and another one from the Docker Desktop Preferences Screen - to make it easier for people like me to locate the setting